### PR TITLE
GraphiQL: meta tags

### DIFF
--- a/graphiql-spring-boot-autoconfigure/src/main/resources/META-INF/resources/index.html
+++ b/graphiql-spring-boot-autoconfigure/src/main/resources/META-INF/resources/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8" />
+    <title>GraphiQL</title>
+    <meta name="robots" content="noindex" />
     <style>
         body {
             height: 100%;


### PR DESCRIPTION
This is a fix for character encoding issue in some browser, e.g. FireFox reports on missing encoding meta tag:
> The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.

Plus we align with other meta tags currently set in `express-graphql`, see https://github.com/graphql/express-graphql/commit/775914b5689cfc781c99cf705292e1dcffd2239a