### PR TITLE
Added Content-Type header to GraphiQL response

### DIFF
--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
@@ -14,8 +14,9 @@ import java.io.IOException;
  */
 @Controller
 public class GraphiQLController {
-    @RequestMapping(value = "${graphiql.mapping:/graphiql}", produces = MediaType.TEXT_HTML_VALUE)
+    @RequestMapping(value = "${graphiql.mapping:/graphiql}")
     public void graphiql(HttpServletResponse response) throws IOException {
+        response.setContentType("text/html; charset=UTF-8");
         StreamUtils.copy(new ClassPathResource("graphiql.html").getInputStream(), response.getOutputStream());
     }
 }


### PR DESCRIPTION
The annotation attribute `produces` is ignored when writing directly on the `OutputStream` of the `response`. I've removed that and now explicitly set the `Content-Type` header before writing to the `OutputStream`, thereby ensuring that the browser understands the response. In my case Google Chrome was showing it as plain text instead of html.