### PR TITLE
reuse jackson configuration for schema parser

### DIFF
--- a/graphql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphql/boot/GraphQLJavaToolsAutoConfiguration.java
+++ b/graphql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphql/boot/GraphQLJavaToolsAutoConfiguration.java
@@ -1,13 +1,16 @@
 package com.oembedler.moon.graphql.boot;
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
+import com.coxautodev.graphql.tools.ObjectMapperConfigurerContext;
 import com.coxautodev.graphql.tools.SchemaParser;
 import com.coxautodev.graphql.tools.SchemaParserBuilder;
 import com.coxautodev.graphql.tools.SchemaParserDictionary;
 import com.coxautodev.graphql.tools.SchemaParserOptions;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.servlet.GraphQLSchemaProvider;
+import graphql.servlet.ObjectMapperConfigurer;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -38,6 +41,9 @@ public class GraphQLJavaToolsAutoConfiguration {
     @Autowired(required = false)
     private SchemaParserOptions options;
 
+    @Autowired(required = false)
+    private ObjectMapperConfigurer objectMapperConfigurer;
+
     @Autowired
     private ApplicationContext applicationContext;
 
@@ -49,28 +55,30 @@ public class GraphQLJavaToolsAutoConfiguration {
         SchemaParserBuilder builder = dictionary != null ? new SchemaParserBuilder(dictionary) : new SchemaParserBuilder();
 
         Resource[] resources = applicationContext.getResources("classpath*:**/*.graphqls");
-        if(resources.length <= 0) {
+        if (resources.length <= 0) {
             throw new IllegalStateException("No *.graphqls files found on classpath.  Please add a graphql schema to the classpath or add a SchemaParser bean to your application context.");
         }
 
-        for(Resource resource : resources) {
+        for (Resource resource : resources) {
             StringWriter writer = new StringWriter();
             IOUtils.copy(resource.getInputStream(), writer);
             builder.schemaString(writer.toString());
         }
 
-        if(scalars != null) {
+        if (scalars != null) {
             builder.scalars(scalars);
         }
 
-        if(options != null) {
+        if (options != null) {
             builder.options(options);
+        } else if (objectMapperConfigurer != null) {
+            com.coxautodev.graphql.tools.ObjectMapperConfigurer c = (mapper, context) -> objectMapperConfigurer.configure(mapper);
+            builder.options(SchemaParserOptions.newOptions().objectMapperConfigurer(c).build());
         }
 
         return builder.resolvers(resolvers)
-            .build();
+                .build();
     }
-
 
     @Bean
     @ConditionalOnBean(SchemaParser.class)


### PR DESCRIPTION
it took me very long to find out that you have to configure jackson in 2 different places - this avoids it.

Additionally, I was thinking about using JacksonAutoConfiguration - is this a good idea?