### PR TITLE
Add configuration parameter to change the GraphiQL page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ graphiql:
     mapping: /graphiql
     endpoint: /graphql
     enabled: true
+    pageTitle: GraphiQL
 ```
 
 # Supported GraphQL-Java Libraries

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
@@ -22,6 +22,9 @@ public class GraphiQLController {
     @Value("${graphiql.endpoint:/graphql}")
     private String graphqlEndpoint;
 
+    @Value("${graphiql.pageTitle:GraphiQL}")
+    private String pageTitle;
+
     @RequestMapping(value = "${graphiql.mapping:/graphiql}")
     public void graphiql(HttpServletResponse response) throws IOException {
         response.setContentType("text/html; charset=UTF-8");
@@ -29,6 +32,7 @@ public class GraphiQLController {
         String template = StreamUtils.copyToString(new ClassPathResource("graphiql.html").getInputStream(), Charset.defaultCharset());
         Map<String, String> replacements = new HashMap<>();
         replacements.put("graphqlEndpoint", graphqlEndpoint);
+        replacements.put("pageTitle", pageTitle);
 
         response.getOutputStream().write(StrSubstitutor.replace(template, replacements).getBytes(Charset.defaultCharset()));
     }

--- a/graphiql-spring-boot-autoconfigure/src/main/resources/graphiql.html
+++ b/graphiql-spring-boot-autoconfigure/src/main/resources/graphiql.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>GraphiQL</title>
+    <title>${pageTitle}</title>
     <meta name="robots" content="noindex" />
     <style>
         body {


### PR DESCRIPTION
A small pull request that adds a simple feature: the ability to change the GraphiQL page title using a Spring Boot parameter (through the standard `application.yml` file or any other mean of setting Spring Boot parameters).

Here is my motivation for this pull request: I'm currently working on a quite big project which has many microservices. Each one of these microservices exposes its own GraphiQL page. I (and my colleagues) end up with many tabs in the browser all having exactly the same name... and it's sometimes a bit difficult to find the one I'm actually interested in! ^^

(P.S. Thank you for this cool project!)