### PR TITLE
Pass all request params from graphiql endpoint to graphql endpoint.

### DIFF
--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
@@ -5,7 +5,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -26,14 +28,25 @@ public class GraphiQLController {
     private String pageTitle;
 
     @RequestMapping(value = "${graphiql.mapping:/graphiql}")
-    public void graphiql(HttpServletResponse response) throws IOException {
+    public void graphiql(HttpServletResponse response, @PathVariable Map<String, String> params) throws IOException {
         response.setContentType("text/html; charset=UTF-8");
 
         String template = StreamUtils.copyToString(new ClassPathResource("graphiql.html").getInputStream(), Charset.defaultCharset());
         Map<String, String> replacements = new HashMap<>();
-        replacements.put("graphqlEndpoint", graphqlEndpoint);
+
+        String endpoint = constructGraphQlEndpoint(params);
+
+        replacements.put("graphqlEndpoint", endpoint);
         replacements.put("pageTitle", pageTitle);
 
         response.getOutputStream().write(StrSubstitutor.replace(template, replacements).getBytes(Charset.defaultCharset()));
+    }
+
+    private String constructGraphQlEndpoint(@RequestParam Map<String, String> params) {
+        String endpoint = graphqlEndpoint;
+        for (Map.Entry<String, String> param : params.entrySet()) {
+            endpoint = endpoint.replaceAll("\\{" + param.getKey() + "}", param.getValue());
+        }
+        return endpoint;
     }
 }


### PR DESCRIPTION
This is useful if you have multi tenant environment and you want to separate
different accounts into different schema.
For example, if you have `/account/{id}/graphiql` and `/account/{id}/graphql`
you want *id* parameter to be passed from iql url to graphql url.