### PR TITLE
Version in Gradle example should match Maven example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ repositories {
 }
 
 dependencies {
-  compile 'com.graphql-java:graphql-spring-boot-starter:3.9.2'
+  compile 'com.graphql-java:graphql-spring-boot-starter:3.10.0'
   
   // to embed GraphiQL tool
-  compile 'com.graphql-java:graphiql-spring-boot-starter:3.9.2'
+  compile 'com.graphql-java:graphiql-spring-boot-starter:3.10.0'
 }
 ```
 


### PR DESCRIPTION
The Maven example showed version 3.10.0, but the Gradle example was still on 3.9.2. I've updated the Gradle example to use 3.10.0 as well.

P.S. How come the 3.10.0 release is not listed on https://github.com/graphql-java/graphql-spring-boot/releases ? This release is available from Maven Central: http://search.maven.org/#artifactdetails%7Ccom.graphql-java%7Cgraphql-spring-boot-starter%7C3.10.0%7Cjar