### PR TITLE
Some styling to prevent voyager graph cut off

### DIFF
--- a/voyager-spring-boot-autoconfigure/src/main/resources/voyager.html
+++ b/voyager-spring-boot-autoconfigure/src/main/resources/voyager.html
@@ -6,7 +6,9 @@
 
     <link rel="stylesheet" href="https://apis.guru/graphql-voyager/releases/v1.x/voyager.css" />
     <script src="https://apis.guru/graphql-voyager/releases/v1.x/voyager.min.js"></script>
+    <meta charset="utf-8">
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
+    <title>GraphQL Voyager</title>
     <style>
      body {
        padding: 0;

--- a/voyager-spring-boot-autoconfigure/src/main/resources/voyager.html
+++ b/voyager-spring-boot-autoconfigure/src/main/resources/voyager.html
@@ -6,6 +6,20 @@
 
     <link rel="stylesheet" href="https://apis.guru/graphql-voyager/releases/v1.x/voyager.css" />
     <script src="https://apis.guru/graphql-voyager/releases/v1.x/voyager.min.js"></script>
+    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
+    <style>
+     body {
+       padding: 0;
+       margin: 0;
+       width: 100%;
+       height: 100vh;
+       overflow: hidden;
+     }
+     #voyager {
+       height: 100%;
+       position: relative;
+     }
+   </style>
 </head>
 <body>
 <div id="voyager">Loading...</div>


### PR DESCRIPTION
Hi,
on my machine it looked like the graph area from voyager was kind of cut of as soon as I start zooming or navigating through the graph diagram. It looked like the display area has only the initial size from the graph.

I added some styles based on the setup of the voyager project itself