### PR TITLE
GraphiQL improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ graphiql:
             variables: variables.graphql
         variables:
             editorTheme: "solarized light"
+    headers:
+        Authorization: "Bearer <your-token>"
 ```
 By default GraphiQL is served from within the package. This can be configured to be served from CDN instead,
 by setting the property `graphiql.cdn.enabled` to `true`.
@@ -127,6 +129,8 @@ You are able to set the GraphiQL props as well. The `graphiql.props.variables` g
 as defined at [GraphiQL Usage](https://github.com/graphql/graphiql#usage). Since setting (large) queries in the 
 properties like this isn't very readable, you can use the properties in the `graphiql.props.resources` group
 to set the classpath resources that should be loaded.
+
+Headers that are used when sending the GraphiQL queries can be set by defining them in the `graphiql.headers` group.
 
 # Supported GraphQL-Java Libraries
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,21 @@ graphiql:
     cdn:
         enabled: false
         version: 0.11.11
+    props:
+        resources:
+            query: query.graphql
+            defaultQuery: defaultQuery.graphql
+            variables: variables.graphql
+        variables:
+            editorTheme: "solarized light"
 ```
 By default GraphiQL is served from within the package. This can be configured to be served from CDN instead,
 by setting the property `graphiql.cdn.enabled` to `true`.
+
+You are able to set the GraphiQL props as well. The `graphiql.props.variables` group can contain any of the props
+as defined at [GraphiQL Usage](https://github.com/graphql/graphiql#usage). Since setting (large) queries in the 
+properties like this isn't very readable, you can use the properties in the `graphiql.props.resources` group
+to set the classpath resources that should be loaded.
 
 # Supported GraphQL-Java Libraries
 

--- a/example-graphql-tools/src/main/resources/application.yml
+++ b/example-graphql-tools/src/main/resources/application.yml
@@ -9,3 +9,6 @@ graphiql:
       query: defaultQuery.graphql
       defaultQuery: defaultQuery.graphql
       variables: defaultQuery.graphql
+  headers:
+    Authorization: "Bearer asdfasdf"
+    Content-Type: "application/json;charset=UTF-8"

--- a/example-graphql-tools/src/main/resources/application.yml
+++ b/example-graphql-tools/src/main/resources/application.yml
@@ -3,3 +3,9 @@ spring:
     name: graphql-java-tools-app
 server:
   port: 9000
+graphiql:
+  props:
+    resources:
+      query: defaultQuery.graphql
+      defaultQuery: defaultQuery.graphql
+      variables: defaultQuery.graphql

--- a/example-graphql-tools/src/main/resources/defaultQuery.graphql
+++ b/example-graphql-tools/src/main/resources/defaultQuery.graphql
@@ -1,0 +1,3 @@
+query {
+    echo(string: "echo")
+}

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
@@ -2,7 +2,9 @@ package com.oembedler.moon.graphiql.boot;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
@@ -37,13 +39,19 @@ public class GraphiQLController {
     @Value("${graphiql.cdn.version:0.11.11}")
     private String graphiqlCdnVersion;
 
+    @Autowired
+    private Environment environment;
+
     private String template;
+    private String props;
 
     @PostConstruct
     public void loadTemplate() throws IOException {
         try (InputStream inputStream = new ClassPathResource("graphiql.html").getInputStream()) {
             template = StreamUtils.copyToString(inputStream, Charset.defaultCharset());
         }
+
+        props = new PropsLoader(environment).load();
     }
 
     @RequestMapping(value = "${graphiql.mapping:/graphiql}")
@@ -69,6 +77,7 @@ public class GraphiQLController {
         replacements.put("pageTitle", pageTitle);
         replacements.put("graphiqlCssUrl", graphiqlCssUrl);
         replacements.put("graphiqlJsUrl", graphiqlJsUrl);
+        replacements.put("props", props);
 
         String populatedTemplate = StrSubstitutor.replace(template, replacements);
 
@@ -89,4 +98,5 @@ public class GraphiQLController {
         }
         return endpoint;
     }
+
 }

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/PropertyGroupReader.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/PropertyGroupReader.java
@@ -1,0 +1,62 @@
+package com.oembedler.moon.graphiql.boot;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+
+import java.util.*;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+class PropertyGroupReader {
+
+    private Environment environment;
+    private String prefix;
+    private Properties props;
+
+    PropertyGroupReader(Environment environment, String prefix) {
+        this.environment = Objects.requireNonNull(environment);
+        this.prefix = Optional.ofNullable(prefix).orElse("");
+    }
+
+    Properties load() {
+        if (props == null) {
+            props = new Properties();
+            loadProps();
+        }
+        return props;
+    }
+
+    private void loadProps() {
+        streamOfPropertySources().forEach(propertySource ->
+                Arrays.stream(propertySource.getPropertyNames())
+                        .filter(this::isWanted)
+                        .forEach(key -> add(propertySource, key)));
+    }
+
+    private Stream<EnumerablePropertySource> streamOfPropertySources() {
+        if (environment instanceof ConfigurableEnvironment) {
+            Iterator<PropertySource<?>> iterator = ((ConfigurableEnvironment) environment).getPropertySources().iterator();
+            Iterable<PropertySource<?>> iterable = () -> iterator;
+            return StreamSupport.stream(iterable.spliterator(), false)
+                    .filter(EnumerablePropertySource.class::isInstance)
+                    .map(EnumerablePropertySource.class::cast);
+        }
+        return Stream.empty();
+    }
+
+    private String withoutPrefix(String key) {
+        return key.replace(prefix, "");
+    }
+
+    private boolean isWanted(String key) {
+        return key.startsWith(prefix);
+    }
+
+    private Object add(EnumerablePropertySource propertySource, String key) {
+        return props.put(withoutPrefix(key), propertySource.getProperty(key));
+    }
+
+}
+

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/PropsLoader.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/PropsLoader.java
@@ -1,0 +1,84 @@
+package com.oembedler.moon.graphiql.boot;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+class PropsLoader {
+
+    private static final String GRAPHIQL_PROPS_PREFIX = "graphiql.props.";
+    private static final String GRAPHIQL_PROPS_RESOURCES_PREFIX = GRAPHIQL_PROPS_PREFIX + "resources.";
+    private static final String GRAPHIQL_PROPS_VALUES_PREFIX = GRAPHIQL_PROPS_PREFIX + "values.";
+
+    private Environment environment;
+
+    PropsLoader(Environment environment) {
+        this.environment = environment;
+    }
+
+    String load() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode props = objectMapper.createObjectNode();
+
+        streamOfPropertySources().forEach(propertySource ->
+                Arrays.stream(propertySource.getPropertyNames())
+                        .filter(this::isPropValue)
+                        .forEach(key -> props.put(toPropKey(key), (String) propertySource.getProperty(key))));
+
+        loadPropFromResource("defaultQuery").ifPresent(it -> props.put("defaultQuery", it));
+        loadPropFromResource("query").ifPresent(it -> props.put("query", it));
+        loadPropFromResource("variables").ifPresent(it -> props.put("variables", it));
+        return objectMapper.writeValueAsString(props);
+    }
+
+    private Stream<EnumerablePropertySource> streamOfPropertySources() {
+        if (environment instanceof ConfigurableEnvironment) {
+            Iterator<PropertySource<?>> iterator = ((ConfigurableEnvironment) environment).getPropertySources().iterator();
+            Iterable<PropertySource<?>> iterable = () -> iterator;
+            return StreamSupport.stream(iterable.spliterator(), false)
+                    .filter(EnumerablePropertySource.class::isInstance)
+                    .map(EnumerablePropertySource.class::cast);
+        }
+        return Stream.empty();
+    }
+
+    private String toPropKey(String key) {
+        return key.replace(GRAPHIQL_PROPS_VALUES_PREFIX, "");
+    }
+
+    private boolean isPropValue(String key) {
+        return key.startsWith(GRAPHIQL_PROPS_VALUES_PREFIX);
+    }
+
+    private Optional<String> loadPropFromResource(String prop) throws IOException {
+        String property = GRAPHIQL_PROPS_RESOURCES_PREFIX + prop;
+        if (environment.containsProperty(property)) {
+            String location = environment.getProperty(property);
+            Resource resource = new ClassPathResource(location);
+            return Optional.of(loadResource(resource));
+        }
+        return Optional.empty();
+    }
+
+    private String loadResource(Resource resource) throws IOException {
+        try (InputStream inputStream = resource.getInputStream()) {
+            return StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+        }
+    }
+
+}

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/PropsLoader.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/PropsLoader.java
@@ -1,11 +1,7 @@
 package com.oembedler.moon.graphiql.boot;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
-import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
@@ -13,11 +9,8 @@ import org.springframework.util.StreamUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Optional;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import java.util.Properties;
 
 class PropsLoader {
 
@@ -32,37 +25,14 @@ class PropsLoader {
     }
 
     String load() throws IOException {
+        PropertyGroupReader reader = new PropertyGroupReader(environment, GRAPHIQL_PROPS_VALUES_PREFIX);
+        Properties props = reader.load();
+
         ObjectMapper objectMapper = new ObjectMapper();
-        ObjectNode props = objectMapper.createObjectNode();
-
-        streamOfPropertySources().forEach(propertySource ->
-                Arrays.stream(propertySource.getPropertyNames())
-                        .filter(this::isPropValue)
-                        .forEach(key -> props.put(toPropKey(key), (String) propertySource.getProperty(key))));
-
         loadPropFromResource("defaultQuery").ifPresent(it -> props.put("defaultQuery", it));
         loadPropFromResource("query").ifPresent(it -> props.put("query", it));
         loadPropFromResource("variables").ifPresent(it -> props.put("variables", it));
         return objectMapper.writeValueAsString(props);
-    }
-
-    private Stream<EnumerablePropertySource> streamOfPropertySources() {
-        if (environment instanceof ConfigurableEnvironment) {
-            Iterator<PropertySource<?>> iterator = ((ConfigurableEnvironment) environment).getPropertySources().iterator();
-            Iterable<PropertySource<?>> iterable = () -> iterator;
-            return StreamSupport.stream(iterable.spliterator(), false)
-                    .filter(EnumerablePropertySource.class::isInstance)
-                    .map(EnumerablePropertySource.class::cast);
-        }
-        return Stream.empty();
-    }
-
-    private String toPropKey(String key) {
-        return key.replace(GRAPHIQL_PROPS_VALUES_PREFIX, "");
-    }
-
-    private boolean isPropValue(String key) {
-        return key.startsWith(GRAPHIQL_PROPS_VALUES_PREFIX);
     }
 
     private Optional<String> loadPropFromResource(String prop) throws IOException {

--- a/graphiql-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphiql-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -29,6 +29,21 @@
       "name": "graphiql.cdn.version",
       "defaultValue": "0.11.11",
       "type": "java.lang.String"
+    },
+    {
+      "name": "graphiql.props.resources.query",
+      "defaultValue": null,
+      "type": "java.lang.String"
+    },
+    {
+      "name": "graphiql.props.resources.defaultQuery",
+      "defaultValue": null,
+      "type": "java.lang.String"
+    },
+    {
+      "name": "graphiql.props.resources.variables",
+      "defaultValue": null,
+      "type": "java.lang.String"
     }
   ]
 }

--- a/graphiql-spring-boot-autoconfigure/src/main/resources/graphiql.html
+++ b/graphiql-spring-boot-autoconfigure/src/main/resources/graphiql.html
@@ -127,17 +127,24 @@
     var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(newUri, { reconnect: true });
     var subscriptionsFetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
 
+    var props = ${props};
+    if (parameters.query) {
+        props.query = parameters.query;
+    }
+    if (parameters.variables) {
+        props.variables = parameters.variables;
+    }
+    if (parameters.operationName) {
+        props.operationName = parameters.operationName;
+    }
+    props.fetcher = subscriptionsFetcher;
+    props.onEditQuery = onEditQuery;
+    props.onEditVariables = onEditVariables;
+    props.onEditOperationName = onEditOperationName;
+
     // Render <GraphiQL /> into the body.
     ReactDOM.render(
-        React.createElement(GraphiQL, {
-            fetcher: subscriptionsFetcher,
-            query: parameters.query,
-            variables: parameters.variables,
-            operationName: parameters.operationName,
-            onEditQuery: onEditQuery,
-            onEditVariables: onEditVariables,
-            onEditOperationName: onEditOperationName
-        }),
+        React.createElement(GraphiQL, props),
         document.body
     );
 </script>

--- a/graphiql-spring-boot-autoconfigure/src/main/resources/graphiql.html
+++ b/graphiql-spring-boot-autoconfigure/src/main/resources/graphiql.html
@@ -88,6 +88,8 @@
         history.replaceState(null, null, newSearch);
     }
 
+    var headers = ${headers};
+
     // Defines a GraphQL fetcher using the fetch API. You're not required to
     // use fetch, and could instead implement graphQLFetcher however you like,
     // as long as it returns a Promise or Observable.
@@ -96,10 +98,7 @@
         // Change this to point wherever you host your GraphQL server.
         return fetch('${graphqlEndpoint}', {
             method: 'post',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            },
+            headers: headers,
             body: JSON.stringify(graphQLParams),
             credentials: 'include'
         }).then(function (response) {


### PR DESCRIPTION
This PR adds a couple of requested features:

* Ability to configure props for GraphiQL through Spring properties, e.g. `defaultQuery`, `query`, etc. See the updated README for details.
* Ability to configure headers to be sent when using GraphiQL, e.g. `graphiql.headers.Authorization`.

Working examples of both use cases can be seen in the **example-graphql-tools** sample app.

@elenigen @aSemy @marceloverdijk Please review