### PR TITLE
Graphiql endpoints configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ Available Spring Boot configuration parameters (either `application.yml` or `app
 ```yaml
 graphiql:
     mapping: /graphiql
-    endpoint: /graphql
+    endpoint:
+      graphql: /graphql
+      subscriptions: /subscriptions
+    static:
+      basePath: /
     enabled: true
     pageTitle: GraphiQL
     cdn:

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLController.java
@@ -32,8 +32,14 @@ import java.util.Properties;
 public class GraphiQLController {
 
     private static final String CDNJS_CLOUDFLARE_COM_AJAX_LIBS_GRAPHIQL = "//cdnjs.cloudflare.com/ajax/libs/graphiql/";
-    @Value("${graphiql.endpoint:/graphql}")
+    @Value("${graphiql.endpoint.graphql:/graphql}")
     private String graphqlEndpoint;
+
+    @Value("${graphiql.endpoint.subscriptions:/subscriptions}")
+    private String subscriptionsEndpoint;
+
+    @Value("${graphiql.static.basePath:/}")
+    private String staticBasePath;
 
     @Value("${graphiql.pageTitle:GraphiQL}")
     private String pageTitle;
@@ -86,17 +92,21 @@ public class GraphiQLController {
     public void graphiql(HttpServletRequest request, HttpServletResponse response, @PathVariable Map<String, String> params) throws IOException {
         response.setContentType("text/html; charset=UTF-8");
 
-        String endpoint = constructGraphQlEndpoint(request, params);
-        Map<String, String> replacements = getReplacements(endpoint);
+        Map<String, String> replacements = getReplacements(
+                constructGraphQlEndpoint(request, params),
+                request.getContextPath() + subscriptionsEndpoint,
+                request.getContextPath() + staticBasePath
+        );
 
         String populatedTemplate = StrSubstitutor.replace(template, replacements);
-        populatedTemplate = addContextPathIfEnabled(request, populatedTemplate);
         response.getOutputStream().write(populatedTemplate.getBytes(Charset.defaultCharset()));
     }
 
-    private Map<String, String> getReplacements(String endpoint) {
+    private Map<String, String> getReplacements(String graphqlEndpoint, String subscriptionsEndpoint, String staticBasePath) {
         Map<String, String> replacements = new HashMap<>();
-        replacements.put("graphqlEndpoint", endpoint);
+        replacements.put("graphqlEndpoint", graphqlEndpoint);
+        replacements.put("subscriptionsEndpoint", subscriptionsEndpoint);
+        replacements.put("staticBasePath", staticBasePath);
         replacements.put("pageTitle", pageTitle);
         replacements.put("graphiqlCssUrl", graphiqlUrl("graphiql.min.css"));
         replacements.put("graphiqlJsUrl", graphiqlUrl("graphiql.min.js"));
@@ -109,17 +119,7 @@ public class GraphiQLController {
         if (graphiqlCdnEnabled && StringUtils.isNotBlank(graphiqlCdnVersion)) {
             return CDNJS_CLOUDFLARE_COM_AJAX_LIBS_GRAPHIQL + graphiqlCdnVersion + "/" + filename;
         }
-        return "/vendor/" + filename;
-    }
-
-    private String addContextPathIfEnabled(HttpServletRequest request, String populatedTemplate) {
-        if (StringUtils.isNotBlank(request.getContextPath())) {
-            String vendorPathWithContext = String.format("%s/vendor", request.getContextPath());
-            populatedTemplate = populatedTemplate
-                    .replaceAll("src=\"/vendor", "src=\"" + vendorPathWithContext)
-                    .replaceAll("href=\"/vendor", "href=\"" + vendorPathWithContext);
-        }
-        return populatedTemplate;
+        return staticBasePath + "vendor/" + filename;
     }
 
     private String constructGraphQlEndpoint(HttpServletRequest request, @RequestParam Map<String, String> params) {

--- a/graphiql-spring-boot-autoconfigure/src/main/resources/graphiql.html
+++ b/graphiql-spring-boot-autoconfigure/src/main/resources/graphiql.html
@@ -24,10 +24,10 @@
         }
     </style>
 
-    <script src="/vendor/es6-promise.auto.min.js"></script>
-    <script src="/vendor/fetch.min.js"></script>
-    <script src="/vendor/react.min.js"></script>
-    <script src="/vendor/react-dom.min.js"></script>
+    <script src="${staticBasePath}vendor/es6-promise.auto.min.js"></script>
+    <script src="${staticBasePath}vendor/fetch.min.js"></script>
+    <script src="${staticBasePath}vendor/react.min.js"></script>
+    <script src="${staticBasePath}vendor/react-dom.min.js"></script>
 
     <link rel="stylesheet" href="${graphiqlCssUrl}"/>
     <script src="${graphiqlJsUrl}"></script>
@@ -121,7 +121,7 @@
         newUri = "ws:";
     }
     newUri += "//" + loc.host;
-    newUri += "/subscriptions";
+    newUri += "${subscriptionsEndpoint}";
 
     var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(newUri, { reconnect: true });
     var subscriptionsFetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);


### PR DESCRIPTION
Fixes #117 

Added GraphiQL configurations for subscriptions endpoint and static content.

The proposed implementation requires a configuration of that type:
```yml
graphiql:
    endpoint:
      graphql: /graphql
      subscriptions: /subscriptions
    static:
      basePath: /
```